### PR TITLE
FIX: keyboard would be for URLs when it should be the default

### DIFF
--- a/js/screens/DiscoverScreen.js
+++ b/js/screens/DiscoverScreen.js
@@ -150,43 +150,52 @@ class DiscoverScreen extends React.Component {
       view: VIEWS.TAG_DETAIL,
     });
 
-    this._fetchTagCommunities(tag);
-    this._fetchHotTopicsForTag(tag);
+    this._fetchTagDetail(tag);
   }
 
-  _fetchHotTopicsForTag(tag) {
-    api
-      .fetchHotTopics(tag, 1)
-      .then(json => {
-        if (tag !== this.state.activeTag) {
-          return; // stale response
-        }
+  async _fetchTagDetail(tag) {
+    const [communitiesResult, hotTopicsResult] = await Promise.allSettled([
+      api.fetchTagCommunities(tag),
+      api.fetchHotTopics(tag, 1),
+    ]);
 
-        const topics = json.hot_topics || [];
-        this.setState({
-          hotTopics: topics,
-          hotTopicsLoading: false,
-          hotTopicsHasMore: Boolean(json.more_topics_url),
-        });
+    if (tag !== this.state.activeTag) {
+      return; // stale response
+    }
 
-        if (topics.length === 0) {
-          this.setState({
-            view: VIEWS.ALL_COMMUNITIES,
-            previousView: VIEWS.SPLASH,
-            communitiesFilter: tag,
-            allCommunities: [],
-            allCommunitiesLoading: true,
-          });
-          this._fetchAllCommunities(tag);
-        }
-      })
-      .catch(e => {
-        console.log(e);
-        if (tag !== this.state.activeTag) {
-          return;
-        }
-        this.setState({ hotTopicsLoading: false });
+    if (communitiesResult.status === 'rejected') {
+      console.log(communitiesResult.reason);
+    }
+    if (hotTopicsResult.status === 'rejected') {
+      console.log(hotTopicsResult.reason);
+    }
+
+    const hotTopicsJson = hotTopicsResult.value;
+    const topics = hotTopicsJson?.hot_topics || [];
+    const loaded = {
+      hotTopicsLoading: false,
+      tagCommunitiesLoading: false,
+      tagCommunities: communitiesResult.value?.topics || [],
+    };
+
+    if (hotTopicsResult.status === 'fulfilled' && topics.length === 0) {
+      this.setState({
+        ...loaded,
+        view: VIEWS.ALL_COMMUNITIES,
+        previousView: VIEWS.SPLASH,
+        communitiesFilter: tag,
+        allCommunities: [],
+        allCommunitiesLoading: true,
       });
+      this._fetchAllCommunities(tag);
+      return;
+    }
+
+    this.setState({
+      ...loaded,
+      hotTopics: topics,
+      hotTopicsHasMore: Boolean(hotTopicsJson?.more_topics_url),
+    });
   }
 
   fetchHotTopics(tag, opts = {}) {
@@ -218,29 +227,6 @@ class DiscoverScreen extends React.Component {
       .catch(e => {
         console.log(e);
         this.setState({ hotTopicsLoading: false });
-      });
-  }
-
-  _fetchTagCommunities(tag) {
-    api
-      .fetchTagCommunities(tag)
-      .then(json => {
-        if (tag !== this.state.activeTag) {
-          return;
-        }
-
-        if (json.topics) {
-          this.setState({
-            tagCommunities: json.topics,
-            tagCommunitiesLoading: false,
-          });
-        } else {
-          this.setState({ tagCommunities: [], tagCommunitiesLoading: false });
-        }
-      })
-      .catch(e => {
-        console.log(e);
-        this.setState({ tagCommunitiesLoading: false });
       });
   }
 

--- a/js/screens/DiscoverScreenComponents/TermBar.js
+++ b/js/screens/DiscoverScreenComponents/TermBar.js
@@ -83,7 +83,7 @@ const TermBar = props => {
           </View>
           <TextInput
             enterKeyHint="search"
-            keyboardType="url"
+            keyboardType={props.addSiteScreenParent ? 'url' : 'default'}
             clearButtonMode="never"
             autoCapitalize="none"
             autoCorrect={false}


### PR DESCRIPTION
In the discover page, the `keyboardType` should be the default not the URL

See images:
before:
<img width="482" height="1009" alt="Screenshot 2026-05-08 at 16 08 34" src="https://github.com/user-attachments/assets/d20ac274-6e77-4532-aa06-b3bcfaa93889" />
Now:
<img width="486" height="1041" alt="Screenshot 2026-05-08 at 16 08 24" src="https://github.com/user-attachments/assets/e364d51a-f936-406b-9428-12d9ba084f97" />

Add community url page stays the same
<img width="474" height="998" alt="Screenshot 2026-05-08 at 16 08 17" src="https://github.com/user-attachments/assets/158ad71d-234c-49ff-9cb4-57e2edb2a26e" />

Also fixed an issue where we could see 2 loading when fetching tags