### PR TITLE
FIX: keyboard should not search on first char

### DIFF
--- a/js/screens/DiscoverScreen.js
+++ b/js/screens/DiscoverScreen.js
@@ -533,6 +533,7 @@ class DiscoverScreen extends React.Component {
       <BottomTabBarHeightContext.Consumer>
         {tabBarHeight => (
           <SafeAreaView style={{ flex: 1, backgroundColor: theme.background }}>
+            {this._renderSearchBox()}
             {this._renderContent(tabBarHeight)}
             <Toast config={toastConfig} />
           </SafeAreaView>
@@ -566,7 +567,6 @@ class DiscoverScreen extends React.Component {
         onSelectTag={tag => this.onSelectTag(tag)}
         onSelectRecent={() => this._goToAllCommunitiesFromSplash('recent')}
         onSeeAllCommunities={() => this._goToAllCommunitiesFromSplash()}
-        renderSearchBox={() => this._renderSearchBox()}
       />
     );
   }
@@ -595,7 +595,6 @@ class DiscoverScreen extends React.Component {
           }
         }}
         onEndReached={() => this._fetchNextSearchPage()}
-        renderSearchBox={() => this._renderSearchBox()}
         renderSiteItem={({ item }) => this._renderSiteItem({ item })}
       />
     );
@@ -623,7 +622,6 @@ class DiscoverScreen extends React.Component {
         }}
         onExploreMore={() => this._navigateToSplash()}
         onSelectTag={key => this._selectFromTagDetail(key)}
-        renderSearchBox={() => this._renderSearchBox()}
       />
     );
   }
@@ -639,7 +637,6 @@ class DiscoverScreen extends React.Component {
         selectionCount={this.state.selectionCount}
         tabBarHeight={tabBarHeight}
         onSelectFilter={key => this._selectCommunitiesFilter(key)}
-        renderSearchBox={() => this._renderSearchBox()}
         renderSiteItem={({ item }) => this._renderSiteItem({ item })}
       />
     );
@@ -676,7 +673,6 @@ class DiscoverScreen extends React.Component {
           this._fetchCommunityHotTopics(community.featured_link);
         }}
         onExploreMore={() => this._navigateToSplash()}
-        renderSearchBox={() => this._renderSearchBox()}
       />
     );
   }

--- a/js/screens/DiscoverScreenComponents/views/AllCommunitiesView.js
+++ b/js/screens/DiscoverScreenComponents/views/AllCommunitiesView.js
@@ -19,7 +19,6 @@ const AllCommunitiesView = props => {
     selectionCount,
     tabBarHeight,
     onSelectFilter,
-    renderSearchBox,
     renderSiteItem,
   } = props;
 
@@ -31,7 +30,6 @@ const AllCommunitiesView = props => {
 
   return (
     <View style={sharedStyles.container}>
-      {renderSearchBox()}
       <TagFilterBar
         activeKey={communitiesFilter}
         splashTags={splashTags}

--- a/js/screens/DiscoverScreenComponents/views/CommunityDetailView.js
+++ b/js/screens/DiscoverScreenComponents/views/CommunityDetailView.js
@@ -26,7 +26,6 @@ const CommunityDetailView = props => {
     onEndReached,
     onRefresh,
     onExploreMore,
-    renderSearchBox,
   } = props;
 
   if (!community) {
@@ -46,7 +45,6 @@ const CommunityDetailView = props => {
 
   return (
     <View style={sharedStyles.container}>
-      {renderSearchBox()}
       <TagDetailHeader title={community.title} onBack={() => onBack()} />
       <DiscoverTopicList
         topics={communityTopics}

--- a/js/screens/DiscoverScreenComponents/views/SearchView.js
+++ b/js/screens/DiscoverScreenComponents/views/SearchView.js
@@ -29,7 +29,6 @@ const SearchView = props => {
     onResetToSplash,
     onRefresh,
     onEndReached,
-    renderSearchBox,
     renderSiteItem,
   } = props;
 
@@ -70,7 +69,6 @@ const SearchView = props => {
 
   return (
     <View style={sharedStyles.container}>
-      {renderSearchBox()}
       <FlatList
         keyboardDismissMode="on-drag"
         keyExtractor={item => String(item.id || item.featured_link)}

--- a/js/screens/DiscoverScreenComponents/views/SplashView.js
+++ b/js/screens/DiscoverScreenComponents/views/SplashView.js
@@ -14,12 +14,10 @@ const SplashView = props => {
     onSelectTag,
     onSelectRecent,
     onSeeAllCommunities,
-    renderSearchBox,
   } = props;
 
   return (
     <View style={sharedStyles.container}>
-      {renderSearchBox()}
       <TagSplash
         tags={splashTags}
         loading={splashTagsLoading}

--- a/js/screens/DiscoverScreenComponents/views/TagDetailView.js
+++ b/js/screens/DiscoverScreenComponents/views/TagDetailView.js
@@ -30,7 +30,6 @@ const TagDetailView = props => {
     onRefresh,
     onExploreMore,
     onSelectTag,
-    renderSearchBox,
   } = props;
 
   const activeTagLabel = activeTag;
@@ -67,7 +66,6 @@ const TagDetailView = props => {
 
   return (
     <View style={sharedStyles.container}>
-      {renderSearchBox()}
       <TagFilterBar
         activeKey={activeTag}
         splashTags={splashTags}

--- a/js/screens/DiscoverScreenComponents/views/__tests__/AllCommunitiesView.test.js
+++ b/js/screens/DiscoverScreenComponents/views/__tests__/AllCommunitiesView.test.js
@@ -36,7 +36,6 @@ const baseProps = {
   selectionCount: 0,
   tabBarHeight: 0,
   onSelectFilter: () => {},
-  renderSearchBox: () => null,
   renderSiteItem: () => null,
 };
 

--- a/js/screens/DiscoverScreenComponents/views/__tests__/CommunityDetailView.test.js
+++ b/js/screens/DiscoverScreenComponents/views/__tests__/CommunityDetailView.test.js
@@ -60,7 +60,6 @@ const baseProps = {
   onEndReached: () => {},
   onRefresh: () => {},
   onExploreMore: () => {},
-  renderSearchBox: () => null,
 };
 
 describe('CommunityDetailView (screen view)', () => {

--- a/js/screens/DiscoverScreenComponents/views/__tests__/SearchView.test.js
+++ b/js/screens/DiscoverScreenComponents/views/__tests__/SearchView.test.js
@@ -30,7 +30,6 @@ const baseProps = {
   onResetToSplash: () => {},
   onRefresh: () => {},
   onEndReached: () => {},
-  renderSearchBox: () => null,
   renderSiteItem: () => null,
 };
 

--- a/js/screens/DiscoverScreenComponents/views/__tests__/SplashView.test.js
+++ b/js/screens/DiscoverScreenComponents/views/__tests__/SplashView.test.js
@@ -27,8 +27,7 @@ const renderWithTheme = async ui => {
 };
 
 describe('SplashView', () => {
-  it('renders the search box and forwards tag props to TagSplash', async () => {
-    const renderSearchBox = jest.fn(() => null);
+  it('forwards tag props to TagSplash', async () => {
     const onSelectTag = jest.fn();
     const tags = ['ai', 'finance'];
 
@@ -39,11 +38,8 @@ describe('SplashView', () => {
         onSelectTag={onSelectTag}
         onSelectRecent={() => {}}
         onSeeAllCommunities={() => {}}
-        renderSearchBox={renderSearchBox}
       />,
     );
-
-    expect(renderSearchBox).toHaveBeenCalled();
 
     const tagSplash = tree.root.findByType(MockTagSplash);
     expect(tagSplash.props.tags).toBe(tags);
@@ -62,7 +58,6 @@ describe('SplashView', () => {
         onSelectTag={onSelectTag}
         onSelectRecent={onSelectRecent}
         onSeeAllCommunities={onSeeAllCommunities}
-        renderSearchBox={() => null}
       />,
     );
 

--- a/js/screens/DiscoverScreenComponents/views/__tests__/TagDetailView.test.js
+++ b/js/screens/DiscoverScreenComponents/views/__tests__/TagDetailView.test.js
@@ -58,7 +58,6 @@ const baseProps = {
   onRefresh: () => {},
   onExploreMore: () => {},
   onSelectTag: () => {},
-  renderSearchBox: () => null,
 };
 
 describe('TagDetailView', () => {


### PR DESCRIPTION
Typing the first character in the Discover search box flipped the view from SPLASH to SEARCH. Since SplashView and SearchView are different components because of the rerendering react would dismiss the keyboard.

Now: 

https://github.com/user-attachments/assets/87a90f40-d164-48e9-8c50-d194ffe5ca86


https://github.com/user-attachments/assets/5cda07e1-857a-4a72-aa1f-6834dec65a89

